### PR TITLE
Add a few configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ route, it will be a combination of the controllers name and the route functions 
 If true (the default), the rate limiter will send response headers: `Retry-After`, `X-RateLimit-Limit`,
 `X-Retry-Remaining`, and `X-Retry-Reset`.
 
+### keyGenerator: (request: any) => string
+
+This defines how the rate limiter will extract the unique key for each request. The default implementation
+uses `request.user.id` if `request.user` is present, otherwise it uses `request.ip`. This can be overridden
+if users are uniquely identified in some other manner on the request object.
+
 ## Examples
 
 ### With Redis

--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ By default, if you don't set this up, the underlying library will use a `keyPref
 For instance if you have the decorator on a controller, the `keyPrefix` will be the controllers name. If used on a
 route, it will be a combination of the controllers name and the route functions name.
 
+### headers: boolean
+
+If true (the default), the rate limiter will send response headers: `Retry-After`, `X-RateLimit-Limit`,
+`X-Retry-Remaining`, and `X-Retry-Reset`.
+
 ## Examples
 
 ### With Redis

--- a/lib/__tests__/service.spec.ts
+++ b/lib/__tests__/service.spec.ts
@@ -120,26 +120,31 @@ describe('service', () => {
         it('should set headers', async () => {
             executionContext = fakeExecutionContext(undefined, { header: jest.fn() }) as any;
             await rateLimiterService.executeRateLimiter(executionContext);
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenNthCalledWith(
-                1,
+            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledTimes(4);
+            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
                 'Retry-After',
                 expect.anything(),
             );
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenNthCalledWith(
-                2,
+            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
                 'X-RateLimit-Limit',
                 expect.anything(),
             );
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenNthCalledWith(
-                3,
+            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
                 'X-Retry-Remaining',
                 undefined,
             );
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenNthCalledWith(
-                4,
+            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
                 'X-Retry-Reset',
                 expect.anything(),
             );
+        });
+
+        it('should not set headers if headers option is false', async () => {
+            const mockOptions = { headers: false };
+            reflector.get = jest.fn(() => mockOptions) as any;
+            executionContext = fakeExecutionContext(undefined, { header: jest.fn() }) as any;
+            await rateLimiterService.executeRateLimiter(executionContext);
+            expect(executionContext.switchToHttp().getResponse().set).not.toHaveBeenCalled();
         });
 
         it('should throw TooManyRequests exception if rate limit exceeded', async () => {

--- a/lib/__tests__/service.spec.ts
+++ b/lib/__tests__/service.spec.ts
@@ -78,7 +78,7 @@ describe('service', () => {
             expect(executionContext.switchToHttp().getResponse().header).not.toHaveBeenCalled();
         });
 
-        it('should use response.set if defined and response.set is not (Fastify)', async () => {
+        it('should use response.header if defined and response.set is not (Fastify)', async () => {
             executionContext = fakeExecutionContext(undefined, { header: jest.fn() }) as any;
             await rateLimiterService.executeRateLimiter(executionContext);
             expect(executionContext.switchToHttp().getResponse().header).toHaveBeenCalled();
@@ -134,20 +134,20 @@ describe('service', () => {
         it('should set headers', async () => {
             executionContext = fakeExecutionContext(undefined, { header: jest.fn() }) as any;
             await rateLimiterService.executeRateLimiter(executionContext);
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledTimes(4);
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
+            expect(executionContext.switchToHttp().getResponse().header).toHaveBeenCalledTimes(4);
+            expect(executionContext.switchToHttp().getResponse().header).toHaveBeenCalledWith(
                 'Retry-After',
                 expect.anything(),
             );
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
+            expect(executionContext.switchToHttp().getResponse().header).toHaveBeenCalledWith(
                 'X-RateLimit-Limit',
                 expect.anything(),
             );
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
+            expect(executionContext.switchToHttp().getResponse().header).toHaveBeenCalledWith(
                 'X-Retry-Remaining',
                 undefined,
             );
-            expect(executionContext.switchToHttp().getResponse().set).toHaveBeenCalledWith(
+            expect(executionContext.switchToHttp().getResponse().header).toHaveBeenCalledWith(
                 'X-Retry-Reset',
                 expect.anything(),
             );
@@ -158,7 +158,7 @@ describe('service', () => {
             reflector.get = jest.fn(() => mockOptions) as any;
             executionContext = fakeExecutionContext(undefined, { header: jest.fn() }) as any;
             await rateLimiterService.executeRateLimiter(executionContext);
-            expect(executionContext.switchToHttp().getResponse().set).not.toHaveBeenCalled();
+            expect(executionContext.switchToHttp().getResponse().header).not.toHaveBeenCalled();
         });
 
         it('should throw TooManyRequests exception if rate limit exceeded', async () => {

--- a/lib/__tests__/service.spec.ts
+++ b/lib/__tests__/service.spec.ts
@@ -117,6 +117,20 @@ describe('service', () => {
             );
         });
 
+        it('should use keyGenerator option to generate key if specified', async () => {
+            const mockOptions = {
+                keyGenerator: (request: any) => request.accountId,
+            };
+            reflector.get = jest.fn(() => mockOptions) as any;
+            executionContext = fakeExecutionContext({ accountId: 'account-id' }) as any;
+            const consumeMock = jest.fn(() => ({ msBeforeNext: 1000 }));
+            rateLimiterService.getRateLimiter = jest.fn(() => ({
+                consume: consumeMock,
+            })) as any;
+            await rateLimiterService.executeRateLimiter(executionContext);
+            expect(consumeMock).toHaveBeenCalledWith('account-id', expect.anything());
+        });
+
         it('should set headers', async () => {
             executionContext = fakeExecutionContext(undefined, { header: jest.fn() }) as any;
             await rateLimiterService.executeRateLimiter(executionContext);

--- a/lib/default-options.ts
+++ b/lib/default-options.ts
@@ -6,4 +6,5 @@ export const defaultRateLimiterOptions: RateLimiterModuleOptions = {
     duration: 1,
     pointsConsumed: 1,
     headers: true,
+    keyGenerator: (request: any) => (request.user ? request.user.id : request.ip),
 };

--- a/lib/default-options.ts
+++ b/lib/default-options.ts
@@ -5,4 +5,5 @@ export const defaultRateLimiterOptions: RateLimiterModuleOptions = {
     points: 4,
     duration: 1,
     pointsConsumed: 1,
+    headers: true,
 };

--- a/lib/rate-limiter.interface.ts
+++ b/lib/rate-limiter.interface.ts
@@ -9,6 +9,7 @@ export interface RateLimiterModuleOptions extends Partial<IRateLimiterMongoOptio
     type?: RateLimiterType;
     pointsConsumed?: number;
     headers?: boolean;
+    keyGenerator?: (req: any) => string;
 }
 
 export interface RateLimiterOptionsFactory {

--- a/lib/rate-limiter.interface.ts
+++ b/lib/rate-limiter.interface.ts
@@ -8,6 +8,7 @@ export type RateLimiterType = 'Redis' | 'Memcache' | 'Postgres' | 'MySQL' | 'Mem
 export interface RateLimiterModuleOptions extends Partial<IRateLimiterMongoOptions> {
     type?: RateLimiterType;
     pointsConsumed?: number;
+    headers?: boolean;
 }
 
 export interface RateLimiterOptionsFactory {

--- a/lib/rate-limiter.service.ts
+++ b/lib/rate-limiter.service.ts
@@ -77,6 +77,7 @@ export class RateLimiterService {
         const points: number = reflectedOptions.points ?? this.options.points;
         const pointsConsumed: number = reflectedOptions.pointsConsumed ?? this.options.pointsConsumed;
         const sendHeaders = reflectedOptions.headers ?? this.options.headers;
+        const keyGenerator = reflectedOptions.keyGenerator ?? this.options.keyGenerator;
 
         let keyPrefix: string;
         if (reflectedOptions.keyPrefix) {
@@ -97,7 +98,7 @@ export class RateLimiterService {
         if (!response.set && response.header) response.set = response.header;
         else if (!response.set) throw new Error('Cannot determine method to set response headers');
 
-        const key = request.user ? request.user.id : request.ip;
+        const key = keyGenerator(request);
 
         try {
             const rateLimiterResponse: RateLimiterRes = await rateLimiter.consume(key, pointsConsumed);


### PR DESCRIPTION
- `header` (boolean): disable sending response headers
- `keyGenerator` (function): override extracting user info from the request

Also a tiny refactor to not modify the response object in the fastify case.